### PR TITLE
Publish NC and IA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 scripts/data/geospatial/*
+scripts/.env
 *scripts/reproject.py
 *scripts/mongo-to-csv.py
 *scripts/sample.ipynb

--- a/map/config/map.js
+++ b/map/config/map.js
@@ -12,12 +12,12 @@ export const config = {
 // sources for the map layers
 export const sources = {
     house: {
-        type: 'vector', // last refreshed 9/29/2021
-        tiles: ['https://vectortileservices3.arcgis.com/BrDfCNAt6y4CiXSR/arcgis/rest/services/allhousefinal09291/VectorTileServer/tile/{z}/{y}/{x}.pbf'],
+        type: 'vector', // last refreshed 4/12/2022
+        tiles: ['https://vectortileservices3.arcgis.com/BrDfCNAt6y4CiXSR/arcgis/rest/services/all_house_final_0412/VectorTileServer/tile/{z}/{y}/{x}.pbf'],
     },
     senate: {
-        type: 'vector', // last refreshed 9/29/2021
-        tiles: ['https://vectortileservices3.arcgis.com/BrDfCNAt6y4CiXSR/arcgis/rest/services/allsenatefinal09291/VectorTileServer/tile/{z}/{y}/{x}.pbf'],
+        type: 'vector', // last refreshed 4/12/2022
+        tiles: ['https://vectortileservices3.arcgis.com/BrDfCNAt6y4CiXSR/arcgis/rest/services/all_senate_final_0412/VectorTileServer/tile/{z}/{y}/{x}.pbf'],
     }
 }
 
@@ -25,7 +25,7 @@ export const layers = [
     {
       id: "house-fill",
       source: 'house',
-	  'source-layer': 'allhousefinal0929_0',
+	  'source-layer': 'all_house_final_0412_0',
       type: 'fill',
       paint: {
         'fill-color': [
@@ -54,7 +54,7 @@ export const layers = [
     {
         id: "senate-fill",
         source: 'senate',
-		'source-layer': 'allsenatefinal0929_0',
+		'source-layer': 'all_senate_final_0412_0',
         type: 'fill',
         paint: { 
             'fill-color': [
@@ -84,7 +84,7 @@ export const layers = [
 	{
 		id: "house-highlight",
 		source: "house",
-		'source-layer': 'allhousefinal0929_0',
+		'source-layer': 'all_house_final_0412_0',
 		type: "line",
 		filter: ['in', 'ccid', ''],
 		paint: {
@@ -95,7 +95,7 @@ export const layers = [
 	{
 		id: "senate-highlight",
 		source: "senate",
-		'source-layer': 'allsenatefinal0929_0',
+		'source-layer': 'all_senate_final_0412_0',
 		type: "line",
 		filter: ['in', 'ccid', ''],
 		paint: {

--- a/scripts/append.py
+++ b/scripts/append.py
@@ -21,9 +21,6 @@ import pandas as pd
 import geopandas as gpd
 from pathlib import Path
 
-# TEMP(matt): for the time being, we want to remove NC and IA from our launch states
-SKIP_STATES = ['NC', 'IA']
-
 
 def append_scores_for_chamber(legi_df, raw_dir, cleaned_dir):
     for raw_shape in sorted(raw_dir.glob("*.geojson")):
@@ -35,130 +32,130 @@ def append_scores_for_chamber(legi_df, raw_dir, cleaned_dir):
 
             pdb.set_trace()
         # if there's a ccid field, append the score
-        if 'ccid' not in raw_gdf.columns:
-            print('theres no ccid field. pass.')
+        if "ccid" not in raw_gdf.columns:
+            print("theres no ccid field. pass.")
             continue
 
-        clean_gdf = raw_gdf.merge(legi_df[['ccid', 'cc_score']], on='ccid')
+        clean_gdf = raw_gdf.merge(legi_df[["ccid", "cc_score"]], on="ccid")
 
         # if there are no scores for this state, continue
-        state_abbr = raw_shape.stem.split('-')[0]
+        state_abbr = raw_shape.stem.split("-")[0]
 
-        if not len(clean_gdf) or state_abbr in SKIP_STATES:
+        if not len(clean_gdf):
             print(
-                f'Skipping {raw_shape.name}, no cc scores to include (or a skip state).'
+                f"Skipping {raw_shape.name}, no cc scores to include (or a skip state)."
             )
             continue
 
         # QA/QC check
-        print(f'Appended {raw_shape} is {len(clean_gdf)} vs. {len(raw_gdf)}')
+        print(f"Appended {raw_shape} is {len(clean_gdf)} vs. {len(raw_gdf)}")
 
-        clean_gdf.to_file(cleaned_dir / raw_shape.name, driver='GeoJSON')
+        clean_gdf.to_file(cleaned_dir / raw_shape.name, driver="GeoJSON")
 
 
 if __name__ == "__main__":
     """pull data from MongoDB"""
-    print('connect to the production database')
+    print("connect to the production database")
     # read in regions data from mongodb
-    username = urllib.parse.quote_plus('browse-data')
-    password = urllib.parse.quote_plus('climate-cabinet-1963')
+    username = urllib.parse.quote_plus("browse-data")
+    password = urllib.parse.quote_plus("climate-cabinet-1963")
     client = pymongo.MongoClient(
         f'mongodb+srv://{urllib.parse.quote_plus("browse-data")}:'
         f'{urllib.parse.quote_plus("climate-cabinet-1963")}'
-        '@cluster1.kmeus.mongodb.net/'
+        "@cluster1.kmeus.mongodb.net/"
     )
-    db = client['production-8-19-2021']
+    db = client["production-3-8-2022"]
     df = pd.DataFrame(list(db.region.find()))
     df1 = pd.DataFrame(list(db.representative.find()))
     client.close()
 
     """ create tidy dataframe """
-    print('creating tidy dataframe')
+    print("creating tidy dataframe")
     # expanded incumbents
     df_incumbents = pd.concat(
         [
-            df.drop(['incumbents'], axis=1),
-            df['incumbents'].apply(pd.Series)[0].apply(pd.Series)[['name', 'rep']],
-            df['incumbents'].apply(pd.Series)[1].apply(pd.Series)[['name', 'rep']],
+            df.drop(["incumbents"], axis=1),
+            df["incumbents"].apply(pd.Series)[0].apply(pd.Series)[["name", "rep"]],
+            df["incumbents"].apply(pd.Series)[1].apply(pd.Series)[["name", "rep"]],
         ],
         axis=1,
     )
 
     # filtered dataframe to just show necessary columns for state house & senate
     regions = df_incumbents[
-        (df_incumbents['_cls'] == 'Region.District.StateLegDistLower')
-        | (df_incumbents['_cls'] == 'Region.District.StateLegDistUpper')
-    ][['state_abbr', 'geoid', 'ccid', 'district_type', 'name', 'rep']]
+        (df_incumbents["_cls"] == "Region.District.StateLegDistLower")
+        | (df_incumbents["_cls"] == "Region.District.StateLegDistUpper")
+    ][["state_abbr", "geoid", "ccid", "district_type", "name", "rep"]]
 
     # rename columns
     regions.columns = [
-        'state_abbr',
-        'geoid',
-        'ccid',
-        'chamber',
-        'district_name',
-        'incumbent_name_1',
-        'incumbent_name_2',
-        'district_1',
-        'district_2',
+        "state_abbr",
+        "geoid",
+        "ccid",
+        "chamber",
+        "district_name",
+        "incumbent_name_1",
+        "incumbent_name_2",
+        "district_1",
+        "district_2",
     ]
 
     # grab only necessary columns for future merging
-    regions = regions[['state_abbr', 'geoid', 'ccid', 'district_name']]
+    regions = regions[["state_abbr", "geoid", "ccid", "district_name"]]
 
     # filtered representative dataframe
     rep_df = pd.concat(
-        [df1.drop(['office'], axis=1), df1['office'].apply(pd.Series)], axis=1
+        [df1.drop(["office"], axis=1), df1["office"].apply(pd.Series)], axis=1
     )[
         [
-            'full_name',
-            'cc_score',
-            'district_ccid',
-            'district',
-            'seat_number',
-            'party',
-            'is_current',
+            "full_name",
+            "cc_score",
+            "district_ccid",
+            "district",
+            "seat_number",
+            "party",
+            "is_current",
         ]
     ]
 
     # get average score (for current legislators)
     representative = (
         rep_df.query("is_current == True")
-        .groupby('district_ccid')
+        .groupby("district_ccid")
         .mean()
-        .reset_index(drop=False)[['district_ccid', 'cc_score']]
+        .reset_index(drop=False)[["district_ccid", "cc_score"]]
     )
 
     # fill NaN with 999 for cc score
-    representative['cc_score'] = representative['cc_score'].fillna('999')
+    representative["cc_score"] = representative["cc_score"].fillna("999")
 
     # round score to integer
-    representative['cc_score'] = representative['cc_score'].astype(int)
+    representative["cc_score"] = representative["cc_score"].astype(int)
 
     # merge the two dataframes
     ccscorecard_legislator = regions.merge(
-        representative, left_on='ccid', right_on='district_ccid', how='inner'
-    ).drop(columns=['district_ccid'])
+        representative, left_on="ccid", right_on="district_ccid", how="inner"
+    ).drop(columns=["district_ccid"])
 
     # manual edits -- append districts with vacant seats
 
     # set PA House District 113 cc score as SEAT VACANT (444)
     # special election is nov 2021
     ccscorecard_legislator.loc[len(ccscorecard_legislator.index)] = [
-        'PA',
-        '42113',
-        '42113L',
-        'State House District 113',
+        "PA",
+        "42113",
+        "42113L",
+        "State House District 113",
         444,
     ]
 
     # tidy dataframe
     ccscorecard_legislator = ccscorecard_legislator.sort_values(
-        by=['geoid', 'cc_score'], ascending=True
+        by=["geoid", "cc_score"], ascending=True
     )
 
     """ loop through files and add the cc score """
-    print('Adding CC Scores to shapes')
+    print("Adding CC Scores to shapes")
     raw_dir = Path("data/geospatial/clean")
     cleaned_dir = Path("data/geospatial/append")
 
@@ -168,8 +165,8 @@ if __name__ == "__main__":
 
     # handle for house
     append_scores_for_chamber(
-        ccscorecard_legislator, raw_dir / 'house', cleaned_dir / 'house'
+        ccscorecard_legislator, raw_dir / "house", cleaned_dir / "house"
     )
     append_scores_for_chamber(
-        ccscorecard_legislator, raw_dir / 'senate', cleaned_dir / 'senate'
+        ccscorecard_legislator, raw_dir / "senate", cleaned_dir / "senate"
     )


### PR DESCRIPTION
### Motivation
When we launched, we chose to omit NC and IA from our scorecard map. These were decisions made for non-technical reasons, essentially at the request of our political team and partners. We're now ready to include these states in our published map. These changes put those states into production, as well as a few minor tweaks to the scripts packaging our tilesets.

### Changes
* Point the Mapbox application towards a new set of tilesets, which include NC and IA.
* Remove the `SKIP_STATES` constant from `scripts/append.py`
* Run the `scripts/` files through Black code formatter.